### PR TITLE
Setting change to force 32 bit build

### DIFF
--- a/Exercism Windows Installer.sln
+++ b/Exercism Windows Installer.sln
@@ -13,8 +13,8 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{348E4BA2-A0B4-40A0-90E6-8CC3ADC3B279}.Debug|x64.ActiveCfg = Release|x64
-		{348E4BA2-A0B4-40A0-90E6-8CC3ADC3B279}.Debug|x64.Build.0 = Release|x64
+		{348E4BA2-A0B4-40A0-90E6-8CC3ADC3B279}.Debug|x64.ActiveCfg = Release|x86
+		{348E4BA2-A0B4-40A0-90E6-8CC3ADC3B279}.Debug|x64.Build.0 = Release|x86
 		{348E4BA2-A0B4-40A0-90E6-8CC3ADC3B279}.Debug|x86.ActiveCfg = Release|x86
 		{348E4BA2-A0B4-40A0-90E6-8CC3ADC3B279}.Debug|x86.Build.0 = Release|x86
 		{348E4BA2-A0B4-40A0-90E6-8CC3ADC3B279}.Release|x64.ActiveCfg = Release|x64


### PR DESCRIPTION
I have not been able to get the released version of the windows installer to operate on my 32 bit windows pc.  I went ahead and forked the repo and loaded it locally into VS to see what I can see.  I am not a C# programmer, but figured out how to get the project to build and found a setting that controlled the target build.  Once the target was set for x86 I had no problems running the installer from a local build.  I do not know if other files should be adjusted.  If other changes are required I'd be happy to make the attempt at making them, just point me in the correct direction.