### PR TITLE
Remove dependency on Raize's Folder Selection Dialog

### DIFF
--- a/Delphi/Project/Source/uConfigApiFrm.dfm
+++ b/Delphi/Project/Source/uConfigApiFrm.dfm
@@ -241,9 +241,4 @@ object frmConfigAPI: TfrmConfigAPI
     Left = 296
     Top = 96
   end
-  object RzSelectFolderDialog1: TRzSelectFolderDialog
-    Options = [sfdoContextMenus, sfdoCreateFolderIcon, sfdoDeleteFolderIcon]
-    Left = 452
-    Top = 112
-  end
 end

--- a/Delphi/Project/Source/uConfigApiFrm.pas
+++ b/Delphi/Project/Source/uConfigApiFrm.pas
@@ -5,7 +5,7 @@ interface
 uses
   Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
   Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls, Vcl.ExtCtrls, ovcurl,
-  uTypes, Vcl.Imaging.pngimage, DosCommand, RzShellDialogs;
+  uTypes, Vcl.Imaging.pngimage, DosCommand;
 
 type
   TfrmConfigAPI = class(TForm)
@@ -21,7 +21,6 @@ type
     DosCommand1: TDosCommand;
     mConfigure: TMemo;
     fldSolutionLocation: TEdit;
-    RzSelectFolderDialog1: TRzSelectFolderDialog;
     btnBrowse: TButton;
     Label5: TLabel;
     Label6: TLabel;
@@ -67,10 +66,13 @@ begin
 end;
 
 procedure TfrmConfigAPI.btnBrowseClick(Sender: TObject);
+var
+  folder: string;
 begin
-  if RzSelectFolderDialog1.Execute then
+  folder := fldSolutionLocation.Text;
+  if SelectDirectory('Select Solution Location', '', folder, [sdNewUI, sdNewFolder, sdShowEdit], Self) then
   begin
-    fldSolutionLocation.Text := RzSelectFolderDialog1.SelectedPathName;
+    fldSolutionLocation.Text := folder;
     fldSolutionLocation.OnChange(fldSolutionLocation);
   end;
 end;

--- a/Delphi/Project/Source/uConfigApiFrm.pas
+++ b/Delphi/Project/Source/uConfigApiFrm.pas
@@ -72,7 +72,7 @@ var
   folder: string;
 begin
   folder := fldSolutionLocation.Text;
-  if SelectDirectory('Select Solution Location', '', folder, [sdNewUI, sdNewFolder, sdShowEdit], Self) then
+  if SelectDirectory('Select Solution Location', '', folder, [sdNewUI, sdNewFolder], Self) then
   begin
     fldSolutionLocation.Text := folder;
     fldSolutionLocation.OnChange(fldSolutionLocation);

--- a/Delphi/Project/Source/uConfigApiFrm.pas
+++ b/Delphi/Project/Source/uConfigApiFrm.pas
@@ -43,7 +43,9 @@ type
 
 
 implementation
-uses System.IOUtils;
+uses
+  System.IOUtils,
+  Vcl.FileCtrl;
 {$R *.dfm}
 
 function ShowConfigAPIForm(const aInstallInfo: TInstallInfo): TResultStatus;

--- a/Delphi/Project/Source/uInstallLocationFrm.dfm
+++ b/Delphi/Project/Source/uInstallLocationFrm.dfm
@@ -211,9 +211,4 @@ object frmInstallLocation: TfrmInstallLocation
     TabOrder = 4
     OnClick = btnBrowseClick
   end
-  object RzSelectFolderDialog1: TRzSelectFolderDialog
-    Options = [sfdoContextMenus, sfdoCreateFolderIcon, sfdoDeleteFolderIcon]
-    Left = 440
-    Top = 208
-  end
 end

--- a/Delphi/Project/Source/uInstallLocationFrm.pas
+++ b/Delphi/Project/Source/uInstallLocationFrm.pas
@@ -65,7 +65,7 @@ var
   folder: string;
 begin
   folder := fldLocation.Text;
-  if SelectDirectory('Select Install Location', '', Folder, [sdNewUI, sdNewFolder, sdShowEdit], Self) then
+  if SelectDirectory('Select Install Location', '', Folder, [sdNewUI, sdNewFolder], Self) then
   begin
     fldLocation.Text := folder;
   end;

--- a/Delphi/Project/Source/uInstallLocationFrm.pas
+++ b/Delphi/Project/Source/uInstallLocationFrm.pas
@@ -5,7 +5,7 @@ interface
 uses
   Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
   Vcl.Controls, Vcl.Forms, Vcl.Dialogs, uTypes, Vcl.StdCtrls, Vcl.ExtCtrls,
-  RzShellDialogs, Vcl.Imaging.pngimage, System.UITypes, ovcurl;
+  Vcl.Imaging.pngimage, System.UITypes, ovcurl;
 
 type
   TfrmInstallLocation = class(TForm)
@@ -17,7 +17,6 @@ type
     fldLocation: TEdit;
     Label3: TLabel;
     btnBrowse: TButton;
-    RzSelectFolderDialog1: TRzSelectFolderDialog;
     Label4: TLabel;
     Label5: TLabel;
     OvcURL4: TOvcURL;
@@ -36,7 +35,9 @@ type
   function ShowInstallLocationForm(var aInstallInfo: TInstallInfo): TResultStatus;
 
 implementation
-uses System.IOUtils;
+uses
+  Vcl.FileCtrl,
+  System.IOUtils;
 {$R *.dfm}
 
 var
@@ -60,10 +61,13 @@ begin
 end;
 
 procedure TfrmInstallLocation.btnBrowseClick(Sender: TObject);
+var
+  folder: string;
 begin
-  if RzSelectFolderDialog1.Execute then
+  folder := fldLocation.Text;
+  if SelectDirectory('Select Install Location', '', Folder, [sdNewUI, sdNewFolder, sdShowEdit], Self) then
   begin
-    fldLocation.Text := RzSelectFolderDialog1.SelectedPathName
+    fldLocation.Text := folder;
   end;
 end;
 


### PR DESCRIPTION
IMO, the 'native' one looks nicer (on Windows 10 at least). I've configured it so there is an edit field present, and a button, so users can create a new folder.
The Raize components are not free, AFAIK.