### PR TITLE
Improvements to Windows CLI Installer

### DIFF
--- a/Delphi/Project/ExercismCLIInstaller.dproj
+++ b/Delphi/Project/ExercismCLIInstaller.dproj
@@ -65,8 +65,8 @@
         <Icon_MainIcon>img\ExercismCLIInstaller_Icon.ico</Icon_MainIcon>
         <Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
         <OutputExt>EXE</OutputExt>
-        <UWP_DelphiLogo44>C:\projects.git\Exercism\windows-installer\Resources\exercism.png</UWP_DelphiLogo44>
-        <UWP_DelphiLogo150>C:\projects.git\Exercism\windows-installer\Resources\exercism.png</UWP_DelphiLogo150>
+        <UWP_DelphiLogo44>D:\projects.git\Exercism\exercism-windows-installer\Resources\exercism.png</UWP_DelphiLogo44>
+        <UWP_DelphiLogo150>D:\projects.git\Exercism\exercism-windows-installer\Resources\exercism.png</UWP_DelphiLogo150>
         <VerInfo_MajorVer>2</VerInfo_MajorVer>
         <VerInfo_PreRelease>true</VerInfo_PreRelease>
         <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
@@ -87,8 +87,8 @@
         <AppEnableHighDPI>true</AppEnableHighDPI>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <Icon_MainIcon>img\ExercismCLIInstaller_Icon.ico</Icon_MainIcon>
-        <UWP_DelphiLogo44>C:\projects.git\Exercism\windows-installer\Resources\exercism.png</UWP_DelphiLogo44>
-        <UWP_DelphiLogo150>C:\projects.git\Exercism\windows-installer\Resources\exercism.png</UWP_DelphiLogo150>
+        <UWP_DelphiLogo44>D:\projects.git\Exercism\exercism-windows-installer\Resources\exercism.png</UWP_DelphiLogo44>
+        <UWP_DelphiLogo150>D:\projects.git\Exercism\exercism-windows-installer\Resources\exercism.png</UWP_DelphiLogo150>
         <VerInfo_MajorVer>2</VerInfo_MajorVer>
         <VerInfo_Debug>true</VerInfo_Debug>
         <VerInfo_PreRelease>true</VerInfo_PreRelease>

--- a/Delphi/Project/ExercismCLIInstaller.dproj
+++ b/Delphi/Project/ExercismCLIInstaller.dproj
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{F8605FE1-AB97-4531-9853-D43F5A666830}</ProjectGuid>
-        <ProjectVersion>18.2</ProjectVersion>
+        <ProjectVersion>18.3</ProjectVersion>
         <FrameworkType>VCL</FrameworkType>
         <MainSource>ExercismCLIInstaller.dpr</MainSource>
         <Base>True</Base>
@@ -93,8 +93,8 @@
         <VerInfo_Debug>true</VerInfo_Debug>
         <VerInfo_PreRelease>true</VerInfo_PreRelease>
         <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
-        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.1.12;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.1.0;Comments=</VerInfo_Keys>
-        <VerInfo_Build>12</VerInfo_Build>
+        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.1.14;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.1.0;Comments=</VerInfo_Keys>
+        <VerInfo_Build>14</VerInfo_Build>
         <VerInfo_Release>1</VerInfo_Release>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
@@ -108,12 +108,11 @@
         <AppEnableHighDPI>true</AppEnableHighDPI>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_MajorVer>2</VerInfo_MajorVer>
-        <VerInfo_PreRelease>true</VerInfo_PreRelease>
         <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
-        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.1.3;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.1.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.2.10;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.2.0;Comments=</VerInfo_Keys>
         <Icon_MainIcon>img\ExercismCLIInstaller_Icon.ico</Icon_MainIcon>
-        <VerInfo_Build>3</VerInfo_Build>
-        <VerInfo_Release>1</VerInfo_Release>
+        <VerInfo_Build>10</VerInfo_Build>
+        <VerInfo_Release>2</VerInfo_Release>
     </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">

--- a/Delphi/Project/ExercismCLIInstaller.dproj
+++ b/Delphi/Project/ExercismCLIInstaller.dproj
@@ -109,9 +109,9 @@
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_MajorVer>2</VerInfo_MajorVer>
         <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
-        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.2.10;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.2.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.2.11;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.2.0;Comments=</VerInfo_Keys>
         <Icon_MainIcon>img\ExercismCLIInstaller_Icon.ico</Icon_MainIcon>
-        <VerInfo_Build>10</VerInfo_Build>
+        <VerInfo_Build>11</VerInfo_Build>
         <VerInfo_Release>2</VerInfo_Release>
     </PropertyGroup>
     <ItemGroup>

--- a/Delphi/Project/Source/uClientDownloadFrm.pas
+++ b/Delphi/Project/Source/uClientDownloadFrm.pas
@@ -289,9 +289,15 @@ begin
     // Start the download process
     FAsyncResponse := FClient.BeginGet(DoEndDownload, URL, FDownloadStream);
     aStatus := rsFinished;
-  finally
-    FAsyncResponse := nil;
+  except
+    on E: EFCreateError do
+    begin
+      mStatus.Lines.Add(E.Message);
+      btnCancel.Enabled := true;
+      btnStopDownload.Enabled := false;
+    end;
   end;
+  FAsyncResponse := nil;
 end;
 
 procedure TfrmDownload.Unzip_CLI(var aStatus: TResultStatus);

--- a/Delphi/Project/Source/uClientDownloadFrm.pas
+++ b/Delphi/Project/Source/uClientDownloadFrm.pas
@@ -505,8 +505,6 @@ constructor TDownloadVer.create(aFDMEMTable: TFDMemTable);
 var
   IsFound: boolean;
   tag_name_Field: TField;
-  downloadSize,
-  browser_download_urlField: TField;
 begin
   if aFDMemTable.FindFirst then
   begin

--- a/Delphi/Project/Source/uConfigApiFrm.pas
+++ b/Delphi/Project/Source/uConfigApiFrm.pas
@@ -34,7 +34,6 @@ type
   private
     { Private declarations }
     InstallInfo: TInstallInfo;
-//    function ExecuteAndWait(const aCommand: string): Boolean;
   public
     { Public declarations }
   end;
@@ -128,38 +127,5 @@ procedure TfrmConfigAPI.FormCreate(Sender: TObject);
 begin
   SetWindowLong(Handle, GWL_EXSTYLE, WS_EX_APPWINDOW);
 end;
-
-//function TfrmConfigAPI.ExecuteAndWait(const aCommand: string): Boolean;
-//var
-//  tmpStartupInfo: TStartupInfo;
-//  tmpProcessInformation: TProcessInformation;
-//  tmpProgram: String;
-//begin
-//  result := false;
-//  tmpProgram := aCommand.Trim;
-//  FillChar(tmpStartupInfo, SizeOf(tmpStartupInfo), 0);
-//  with tmpStartupInfo do
-//  begin
-//    cb := SizeOf(TStartupInfo);
-//    wShowWindow := SW_HIDE;
-//  end;
-//
-//  if CreateProcess(nil, pchar(tmpProgram), nil, nil, true, CREATE_NO_WINDOW,
-//    nil, nil, tmpStartupInfo, tmpProcessInformation) then
-//  begin
-//    // loop every 10 ms
-//    while WaitForSingleObject(tmpProcessInformation.hProcess, 10) > 0 do
-//    begin
-//      Application.ProcessMessages;
-//    end;
-//    CloseHandle(tmpProcessInformation.hProcess);
-//    CloseHandle(tmpProcessInformation.hThread);
-//    result := true;
-//  end
-//  else
-//  begin
-//    RaiseLastOSError;
-//  end;
-//end;
 
 end.

--- a/Delphi/Project/Source/uConfigApiFrm.pas
+++ b/Delphi/Project/Source/uConfigApiFrm.pas
@@ -72,7 +72,7 @@ var
   folder: string;
 begin
   folder := fldSolutionLocation.Text;
-  if SelectDirectory('Select Solution Location', '', folder, [sdNewUI, sdNewFolder], Self) then
+  if Vcl.FileCtrl.SelectDirectory('Select Solution Location', '', folder, [sdNewUI, sdNewFolder], Self) then
   begin
     fldSolutionLocation.Text := folder;
     fldSolutionLocation.OnChange(fldSolutionLocation);

--- a/Delphi/Project/Source/uConfigApiFrm.pas
+++ b/Delphi/Project/Source/uConfigApiFrm.pas
@@ -34,7 +34,7 @@ type
   private
     { Private declarations }
     InstallInfo: TInstallInfo;
-    function ExecuteAndWait(const aCommand: string): Boolean;
+//    function ExecuteAndWait(const aCommand: string): Boolean;
   public
     { Public declarations }
   end;
@@ -129,37 +129,37 @@ begin
   SetWindowLong(Handle, GWL_EXSTYLE, WS_EX_APPWINDOW);
 end;
 
-function TfrmConfigAPI.ExecuteAndWait(const aCommand: string): Boolean;
-var
-  tmpStartupInfo: TStartupInfo;
-  tmpProcessInformation: TProcessInformation;
-  tmpProgram: String;
-begin
-  result := false;
-  tmpProgram := aCommand.Trim;
-  FillChar(tmpStartupInfo, SizeOf(tmpStartupInfo), 0);
-  with tmpStartupInfo do
-  begin
-    cb := SizeOf(TStartupInfo);
-    wShowWindow := SW_HIDE;
-  end;
-
-  if CreateProcess(nil, pchar(tmpProgram), nil, nil, true, CREATE_NO_WINDOW,
-    nil, nil, tmpStartupInfo, tmpProcessInformation) then
-  begin
-    // loop every 10 ms
-    while WaitForSingleObject(tmpProcessInformation.hProcess, 10) > 0 do
-    begin
-      Application.ProcessMessages;
-    end;
-    CloseHandle(tmpProcessInformation.hProcess);
-    CloseHandle(tmpProcessInformation.hThread);
-    result := true;
-  end
-  else
-  begin
-    RaiseLastOSError;
-  end;
-end;
+//function TfrmConfigAPI.ExecuteAndWait(const aCommand: string): Boolean;
+//var
+//  tmpStartupInfo: TStartupInfo;
+//  tmpProcessInformation: TProcessInformation;
+//  tmpProgram: String;
+//begin
+//  result := false;
+//  tmpProgram := aCommand.Trim;
+//  FillChar(tmpStartupInfo, SizeOf(tmpStartupInfo), 0);
+//  with tmpStartupInfo do
+//  begin
+//    cb := SizeOf(TStartupInfo);
+//    wShowWindow := SW_HIDE;
+//  end;
+//
+//  if CreateProcess(nil, pchar(tmpProgram), nil, nil, true, CREATE_NO_WINDOW,
+//    nil, nil, tmpStartupInfo, tmpProcessInformation) then
+//  begin
+//    // loop every 10 ms
+//    while WaitForSingleObject(tmpProcessInformation.hProcess, 10) > 0 do
+//    begin
+//      Application.ProcessMessages;
+//    end;
+//    CloseHandle(tmpProcessInformation.hProcess);
+//    CloseHandle(tmpProcessInformation.hThread);
+//    result := true;
+//  end
+//  else
+//  begin
+//    RaiseLastOSError;
+//  end;
+//end;
 
 end.

--- a/Delphi/Project/Source/uInstallLocationFrm.pas
+++ b/Delphi/Project/Source/uInstallLocationFrm.pas
@@ -87,7 +87,15 @@ begin
                                     'Shall I create it for you?',
        [fldLocation.Text]),mtError, [mbYes, mbNo],0);
     if lDlgResult = mrYes then
+    begin
       if not System.SysUtils.ForceDirectories(fldLocation.Text) then
+      begin
+        lOKNext := false;
+        MessageDlg(format('Error: Unable to create "%s".'+#13#10+
+                          'Please select another folder or Cancel this installation'
+                          ,[fldLocation.Text]), mtError, [mbOK], 0);
+      end;
+    end
     else
     begin
       lOKNext := false;

--- a/Delphi/Project/Source/uInstallLocationFrm.pas
+++ b/Delphi/Project/Source/uInstallLocationFrm.pas
@@ -65,7 +65,7 @@ var
   folder: string;
 begin
   folder := fldLocation.Text;
-  if SelectDirectory('Select Install Location', '', Folder, [sdNewUI, sdNewFolder], Self) then
+  if vcl.FileCtrl.SelectDirectory('Select Install Location', '', Folder, [sdNewUI, sdNewFolder], Self) then
   begin
     fldLocation.Text := folder;
   end;
@@ -81,13 +81,13 @@ var lOKNext: boolean;
     lDlgResult: word;
 begin
   lOKNext := true;
-  if not DirectoryExists(fldLocation.Text) then
+  if not System.SysUtils.DirectoryExists(fldLocation.Text) then
   begin
     lDlgResult := MessageDlg(format('Directory "%s" does not exist.'+#13#10+
                                     'Shall I create it for you?',
        [fldLocation.Text]),mtError, [mbYes, mbNo],0);
     if lDlgResult = mrYes then
-      ForceDirectories(fldLocation.Text)
+      if not System.SysUtils.ForceDirectories(fldLocation.Text) then
     else
     begin
       lOKNext := false;

--- a/Delphi/Project/Source/uUpdatePath.pas
+++ b/Delphi/Project/Source/uUpdatePath.pas
@@ -63,7 +63,6 @@ var
 begin
   Buf := 'Environment';
   wP := 0;
-//  lParam := 0;
   lP := integer(@Buf[0]);
 
   SendMessageTimeout(HWND_BROADCAST,

--- a/Delphi/Project/Source/uUpdatePath.pas
+++ b/Delphi/Project/Source/uUpdatePath.pas
@@ -56,18 +56,20 @@ end;
 
 class procedure TUpdatePath.BroadcastChange;
 var
-  lParam, wParam: integer;
+  lP: LPARAM;
+  wP: WPARAM;
   Buf : Array[0..10] of Char;
-  aResult: Cardinal;
+  aResult: DWORD;//Cardinal;
 begin
   Buf := 'Environment';
-  wParam := 0;
-  lParam := integer(@Buf[0]);
+  wP := 0;
+//  lParam := 0;
+  lP := integer(@Buf[0]);
 
   SendMessageTimeout(HWND_BROADCAST,
                      WM_SETTINGCHANGE,
-                     wParam,
-                     lParam,
+                     wP,
+                     lP,
                      SMTO_ABORTIFHUNG{SMTO_NORMAL},
                      5000{4000},
                      aResult);

--- a/Delphi/Project/Source/uUpdatePath.pas
+++ b/Delphi/Project/Source/uUpdatePath.pas
@@ -23,7 +23,7 @@ begin
   result := false;
   reg := TRegistry.Create;
   try
-    reg.RootKey := {HKEY_LOCAL_MACHINE{} HKEY_CURRENT_USER{};
+    reg.RootKey := HKEY_CURRENT_USER;
     openResult := reg.OpenKeyReadOnly('Environment');
     if openResult then
     begin
@@ -60,7 +60,6 @@ var
 begin
   Buf := 'Environment';
   wParam := 0;
-  lParam := 0;
   lParam := integer(@Buf[0]);
 
   SendMessageTimeout(HWND_BROADCAST,

--- a/Delphi/Project/Source/uUpdatePath.pas
+++ b/Delphi/Project/Source/uUpdatePath.pas
@@ -37,7 +37,9 @@ begin
         openResult := reg.OpenKey('Environment', true);
         if openResult then
         begin
-          lPath := lPath + ';' + aDir;
+          if not lPath.EndsWith(';') then
+            lPath := lPath + ';';
+          lPath := lPath + aDir;
           reg.WriteString('Path',lPath);
           BroadcastChange;
           result := true;


### PR DESCRIPTION
Better handeling of file/folder access issues, like when user privledges do not permit a folder to be created in a certain location, or a file to be created.

Some minor code clean up.

It was possible for two `;` to be placed at the end of the PATH just prior to appending the CLI path information; fixed.