### PR TITLE
Add ability to verify default TLS is compatible with GutHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,5 @@ paket-files/
 *.vlb
 
 *.dsk
+
+*.~dsk

--- a/Delphi/Project/ExercismCLIInstaller.dproj
+++ b/Delphi/Project/ExercismCLIInstaller.dproj
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{F8605FE1-AB97-4531-9853-D43F5A666830}</ProjectGuid>
-        <ProjectVersion>18.3</ProjectVersion>
+        <ProjectVersion>18.4</ProjectVersion>
         <FrameworkType>VCL</FrameworkType>
         <MainSource>ExercismCLIInstaller.dpr</MainSource>
         <Base>True</Base>
@@ -93,8 +93,8 @@
         <VerInfo_Debug>true</VerInfo_Debug>
         <VerInfo_PreRelease>true</VerInfo_PreRelease>
         <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
-        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.1.14;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.1.0;Comments=</VerInfo_Keys>
-        <VerInfo_Build>14</VerInfo_Build>
+        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.1.15;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.1.0;Comments=</VerInfo_Keys>
+        <VerInfo_Build>15</VerInfo_Build>
         <VerInfo_Release>1</VerInfo_Release>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
@@ -109,9 +109,9 @@
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_MajorVer>2</VerInfo_MajorVer>
         <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
-        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.2.11;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.2.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.2.13;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.2.0;Comments=</VerInfo_Keys>
         <Icon_MainIcon>img\ExercismCLIInstaller_Icon.ico</Icon_MainIcon>
-        <VerInfo_Build>11</VerInfo_Build>
+        <VerInfo_Build>13</VerInfo_Build>
         <VerInfo_Release>2</VerInfo_Release>
     </PropertyGroup>
     <ItemGroup>

--- a/Delphi/Project/ExercismCLIInstaller.dproj
+++ b/Delphi/Project/ExercismCLIInstaller.dproj
@@ -109,9 +109,9 @@
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_MajorVer>2</VerInfo_MajorVer>
         <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
-        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.2.13;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.2.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.2.14;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.2.0;Comments=</VerInfo_Keys>
         <Icon_MainIcon>img\ExercismCLIInstaller_Icon.ico</Icon_MainIcon>
-        <VerInfo_Build>13</VerInfo_Build>
+        <VerInfo_Build>14</VerInfo_Build>
         <VerInfo_Release>2</VerInfo_Release>
     </PropertyGroup>
     <ItemGroup>

--- a/Delphi/Project/Source/uInstallLocationFrm.dfm
+++ b/Delphi/Project/Source/uInstallLocationFrm.dfm
@@ -1,7 +1,6 @@
 object frmInstallLocation: TfrmInstallLocation
   Left = 0
   Top = 0
-  ActiveControl = btnNext
   BorderIcons = []
   BorderStyle = bsDialog
   Caption = 'Exercism CLI Install'
@@ -209,6 +208,7 @@ object frmInstallLocation: TfrmInstallLocation
     Width = 75
     Height = 25
     Caption = '&Next >'
+    Enabled = False
     TabOrder = 2
     OnClick = btnNextClick
   end

--- a/Delphi/Project/Source/uInstallLocationFrm.dfm
+++ b/Delphi/Project/Source/uInstallLocationFrm.dfm
@@ -71,6 +71,29 @@ object frmInstallLocation: TfrmInstallLocation
     ShowHint = True
     Transparent = True
   end
+  object lblUpdateTLS: TOvcURL
+    Left = 189
+    Top = 248
+    Width = 262
+    Height = 13
+    Hint = 
+      'https://support.microsoft.com/en-us/help/3140245/update-to-enabl' +
+      'e-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in'
+    Caption = 'Microsoft instructions for updating default TLS settings'
+    URL = 
+      'https://support.microsoft.com/en-us/help/3140245/update-to-enabl' +
+      'e-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in'
+    Font.Charset = DEFAULT_CHARSET
+    Font.Color = clWindowText
+    Font.Height = -11
+    Font.Name = 'Tahoma'
+    Font.Style = [fsUnderline]
+    ParentFont = False
+    ParentShowHint = False
+    ShowHint = True
+    Transparent = True
+    Visible = False
+  end
   object Panel1: TPanel
     Left = 0
     Top = 0

--- a/Delphi/Project/Source/uInstallLocationFrm.dfm
+++ b/Delphi/Project/Source/uInstallLocationFrm.dfm
@@ -211,4 +211,28 @@ object frmInstallLocation: TfrmInstallLocation
     TabOrder = 4
     OnClick = btnBrowseClick
   end
+  object rcCheckTLSVersion: TRESTClient
+    Accept = 'application/json, text/plain; q=0.9, text/html;q=0.8,'
+    AcceptCharset = 'UTF-8, *;q=0.8'
+    BaseURL = 'https://www.howsmyssl.com/a/check'
+    Params = <>
+    HandleRedirects = True
+    RaiseExceptionOn500 = False
+    Left = 248
+    Top = 48
+  end
+  object rrCheckTLSVersion: TRESTRequest
+    Client = rcCheckTLSVersion
+    Params = <>
+    Response = rResponseCheckTLSVersion
+    SynchronizedEvents = False
+    Left = 328
+    Top = 52
+  end
+  object rResponseCheckTLSVersion: TRESTResponse
+    ContentType = 'application/json'
+    RootElement = 'tls_version'
+    Left = 416
+    Top = 48
+  end
 end

--- a/Delphi/Project/Source/uInstallLocationFrm.dfm
+++ b/Delphi/Project/Source/uInstallLocationFrm.dfm
@@ -15,6 +15,7 @@ object frmInstallLocation: TfrmInstallLocation
   Font.Style = []
   OldCreateOrder = False
   Position = poScreenCenter
+  OnActivate = FormActivate
   OnCreate = FormCreate
   PixelsPerInch = 96
   TextHeight = 13

--- a/Delphi/Project/Source/uInstallLocationFrm.pas
+++ b/Delphi/Project/Source/uInstallLocationFrm.pas
@@ -58,6 +58,7 @@ type
     rcCheckTLSVersion: TRESTClient;
     rrCheckTLSVersion: TRESTRequest;
     rResponseCheckTLSVersion: TRESTResponse;
+    lblUpdateTLS: TOvcURL;
     procedure btnCancelClick(Sender: TObject);
     procedure btnNextClick(Sender: TObject);
     procedure btnBrowseClick(Sender: TObject);

--- a/Delphi/Project/Source/uInstallLocationFrm.pas
+++ b/Delphi/Project/Source/uInstallLocationFrm.pas
@@ -5,7 +5,8 @@ interface
 uses
   Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
   Vcl.Controls, Vcl.Forms, Vcl.Dialogs, uTypes, Vcl.StdCtrls, Vcl.ExtCtrls,
-  Vcl.Imaging.pngimage, System.UITypes, ovcurl;
+  Vcl.Imaging.pngimage, System.UITypes, ovcurl, IPPeerClient, REST.Client,
+  Data.Bind.Components, Data.Bind.ObjectScope;
 
 type
   TfrmInstallLocation = class(TForm)
@@ -21,6 +22,9 @@ type
     Label5: TLabel;
     OvcURL4: TOvcURL;
     Image1: TImage;
+    rcCheckTLSVersion: TRESTClient;
+    rrCheckTLSVersion: TRESTRequest;
+    rResponseCheckTLSVersion: TRESTResponse;
     procedure btnCancelClick(Sender: TObject);
     procedure btnNextClick(Sender: TObject);
     procedure btnBrowseClick(Sender: TObject);


### PR DESCRIPTION
This relates to the issue raised in #33.  This update will inform the user if their installation of Windows needs to be updated.  It also provides a link that they may click that will take them to the Microsoft website to learn more and to apply the hotfix.