### PR TITLE
Fix Windows Locale issue

### DIFF
--- a/Delphi/Project/ExercismCLIInstaller.dproj
+++ b/Delphi/Project/ExercismCLIInstaller.dproj
@@ -109,9 +109,9 @@
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_MajorVer>2</VerInfo_MajorVer>
         <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
-        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.2.16;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.2.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.2.18;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.2.0;Comments=</VerInfo_Keys>
         <Icon_MainIcon>img\ExercismCLIInstaller_Icon.ico</Icon_MainIcon>
-        <VerInfo_Build>16</VerInfo_Build>
+        <VerInfo_Build>18</VerInfo_Build>
         <VerInfo_Release>2</VerInfo_Release>
     </PropertyGroup>
     <ItemGroup>

--- a/Delphi/Project/ExercismCLIInstaller.dproj
+++ b/Delphi/Project/ExercismCLIInstaller.dproj
@@ -93,8 +93,8 @@
         <VerInfo_Debug>true</VerInfo_Debug>
         <VerInfo_PreRelease>true</VerInfo_PreRelease>
         <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
-        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.1.15;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.1.0;Comments=</VerInfo_Keys>
-        <VerInfo_Build>15</VerInfo_Build>
+        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.1.17;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.1.0;Comments=</VerInfo_Keys>
+        <VerInfo_Build>17</VerInfo_Build>
         <VerInfo_Release>1</VerInfo_Release>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
@@ -109,9 +109,9 @@
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <VerInfo_MajorVer>2</VerInfo_MajorVer>
         <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
-        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.2.14;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.2.0;Comments=</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=Exercism;FileDescription=$(MSBuildProjectName);FileVersion=2.0.2.16;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=2.0.2.0;Comments=</VerInfo_Keys>
         <Icon_MainIcon>img\ExercismCLIInstaller_Icon.ico</Icon_MainIcon>
-        <VerInfo_Build>14</VerInfo_Build>
+        <VerInfo_Build>16</VerInfo_Build>
         <VerInfo_Release>2</VerInfo_Release>
     </PropertyGroup>
     <ItemGroup>

--- a/Delphi/Project/Source/uInstallLocationFrm.dfm
+++ b/Delphi/Project/Source/uInstallLocationFrm.dfm
@@ -259,4 +259,11 @@ object frmInstallLocation: TfrmInstallLocation
     Left = 416
     Top = 48
   end
+  object tmrCheckTLS: TTimer
+    Enabled = False
+    Interval = 200
+    OnTimer = tmrCheckTLSTimer
+    Left = 76
+    Top = 200
+  end
 end

--- a/Delphi/Project/Source/uInstallLocationFrm.pas
+++ b/Delphi/Project/Source/uInstallLocationFrm.pas
@@ -183,7 +183,7 @@ begin
   if fStatusCode = 200 then
   begin
     lFormatSettings := TFormatSettings.Create;
-    lformatSettings.ThousandSeparator := ',';
+    lFormatSettings.ThousandSeparator := ',';
     lFormatSettings.DecimalSeparator := '.';
     fTLSVersion := aRESTResponse.JSONText.Replace('"TLS ','');
     fTLSVersion := fTLSVersion

--- a/Delphi/Project/Source/uInstallLocationFrm.pas
+++ b/Delphi/Project/Source/uInstallLocationFrm.pas
@@ -172,8 +172,8 @@ end;
 
 constructor TCheckTLS.Create(aRESTRequest: TRestRequest; aRESTResponse: TRESTResponse);
 var
-  splitVersion: TArray<string>;
   actualVersion: double;
+  lFormatSettings: TFormatSettings;
 begin
   aRESTRequest.Execute;
   fStatusCode := aRESTResponse.StatusCode;
@@ -182,14 +182,19 @@ begin
   fTLSVersion := '';
   if fStatusCode = 200 then
   begin
-    fTLSVersion := aRESTResponse.JSONText.Replace('"','');
-    splitVersion := fTLSVersion.Split([' ']);
-    actualVersion := splitVersion[1].ToDouble;
+    lFormatSettings := TFormatSettings.Create;
+    lformatSettings.ThousandSeparator := ',';
+    lFormatSettings.DecimalSeparator := '.';
+    fTLSVersion := aRESTResponse.JSONText.Replace('"TLS ','');
+    fTLSVersion := fTLSVersion
+                     .Replace('"','')
+                     .Replace(' ','');
+    actualVersion := StrToFloat(fTLSVersion, lFormatSettings);
     fTLSOK := actualVersion >= cDesiredVersion;
     if not fTLSOK then
       fMessageStr := format('TLS Version = %s, must be %0.1f or greater.'+#13#10+
                             'GitHub requires at least version 1.2'+#13#10+
-                            'Please follow the link to Microsoft for instructions on updating Windows.',[splitVersion[1],cDesiredVersion]);
+                            'Please follow the link to Microsoft for instructions on updating Windows.',[fTLSVersion,cDesiredVersion]);
   end
   else
   begin

--- a/Delphi/Project/Source/uInstallLocationFrm.pas
+++ b/Delphi/Project/Source/uInstallLocationFrm.pas
@@ -59,11 +59,13 @@ type
     rrCheckTLSVersion: TRESTRequest;
     rResponseCheckTLSVersion: TRESTResponse;
     lblUpdateTLS: TOvcURL;
+    tmrCheckTLS: TTimer;
     procedure btnCancelClick(Sender: TObject);
     procedure btnNextClick(Sender: TObject);
     procedure btnBrowseClick(Sender: TObject);
     procedure FormCreate(Sender: TObject);
     procedure FormActivate(Sender: TObject);
+    procedure tmrCheckTLSTimer(Sender: TObject);
   private
     { Private declarations }
   public
@@ -150,9 +152,21 @@ begin
 end;
 
 procedure TfrmInstallLocation.FormActivate(Sender: TObject);
+begin
+  tmrCheckTLS.Enabled := true;
+end;
+
+procedure TfrmInstallLocation.FormCreate(Sender: TObject);
+begin
+  NextClicked := false;
+  SetWindowLong(Handle, GWL_EXSTYLE, WS_EX_APPWINDOW);
+end;
+
+procedure TfrmInstallLocation.tmrCheckTLSTimer(Sender: TObject);
 var
   CheckTLS: ICheckTLS;
 begin
+  tmrCheckTLS.Enabled := false;
   CheckTLS := TCheckTLS.Create(rrCheckTLSVersion, rResponseCheckTLSVersion);
   btnNext.Enabled := CheckTLS.TLSok;
   if not btnNext.Enabled then
@@ -160,12 +174,6 @@ begin
     lblUpdateTLS.Visible := true;
     MessageDlg(CheckTLS.ErrMessage,mtError,[mbok],0);
   end;
-end;
-
-procedure TfrmInstallLocation.FormCreate(Sender: TObject);
-begin
-  NextClicked := false;
-  SetWindowLong(Handle, GWL_EXSTYLE, WS_EX_APPWINDOW);
 end;
 
 { TCheckTLS }


### PR DESCRIPTION
Fixes #35

Sometimes Windows Locale settings are such that `","` is used as a decimal indicator instead of `"."`.  When this is the case an exception is raised when trying to convert strings like `"1.2"` to a floating point value.  The conversion routine is expecting `"1,2"` instead.  This update fixes the problem by locally forcing the decimal separator to be `"."` regardless of the users Locale settings.  The value the software is looking to convert will always be using `"."` as a decimal separator.