### PR TITLE
Improve visibility of TLS check failure notification

### DIFF
--- a/Delphi/Project/ExercismCLIInstaller.dproj
+++ b/Delphi/Project/ExercismCLIInstaller.dproj
@@ -100,12 +100,10 @@
         <AppEnableHighDPI>true</AppEnableHighDPI>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <DCC_ExeOutput>Win32\Release</DCC_ExeOutput>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.5.1.2;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=$(MSBuildProjectName);ProductVersion=1.5.0.0;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName)</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.5.2.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=$(MSBuildProjectName);ProductVersion=1.5.2.0;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName)</VerInfo_Keys>
         <DCC_DcuOutput>Win32\Release</DCC_DcuOutput>
         <VerInfo_MinorVer>5</VerInfo_MinorVer>
-        <VerInfo_Release>1</VerInfo_Release>
-        <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
-        <VerInfo_Build>2</VerInfo_Build>
+        <VerInfo_Release>2</VerInfo_Release>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
         <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>

--- a/Delphi/Project/Source/uInstallLocationFrm.dfm
+++ b/Delphi/Project/Source/uInstallLocationFrm.dfm
@@ -71,10 +71,10 @@ object frmInstallLocation: TfrmInstallLocation
     Transparent = True
   end
   object lblUpdateTLS: TOvcURL
-    Left = 189
+    Left = 127
     Top = 248
-    Width = 262
-    Height = 13
+    Width = 386
+    Height = 19
     Hint = 
       'https://support.microsoft.com/en-us/help/3140245/update-to-enabl' +
       'e-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in'
@@ -82,11 +82,13 @@ object frmInstallLocation: TfrmInstallLocation
     URL = 
       'https://support.microsoft.com/en-us/help/3140245/update-to-enabl' +
       'e-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in'
+    Color = clRed
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
-    Font.Height = -11
+    Font.Height = -16
     Font.Name = 'Tahoma'
     Font.Style = [fsUnderline]
+    ParentColor = False
     ParentFont = False
     ParentShowHint = False
     ShowHint = True
@@ -6420,5 +6422,11 @@ object frmInstallLocation: TfrmInstallLocation
     OnTimer = tmrCheckTLSTimer
     Left = 76
     Top = 200
+  end
+  object tmrToggler: TTimer
+    Enabled = False
+    OnTimer = tmrTogglerTimer
+    Left = 508
+    Top = 192
   end
 end

--- a/Delphi/Project/Source/uInstallLocationFrm.pas
+++ b/Delphi/Project/Source/uInstallLocationFrm.pas
@@ -1,5 +1,5 @@
 unit uInstallLocationFrm;
-
+{_define SimTLSCheckFailure}
 interface
 
 uses
@@ -192,10 +192,11 @@ var
   actualVersion: double;
   lFormatSettings: TFormatSettings;
 begin
+  fTLSOK := false;
+  {$ifndef SimTLSCheckFailure}
   aRESTRequest.Execute;
   fStatusCode := aRESTResponse.StatusCode;
   fMessageStr := '';
-  fTLSOK := false;
   fTLSVersion := '';
   if fStatusCode = 200 then
   begin
@@ -211,13 +212,18 @@ begin
     if not fTLSOK then
       fMessageStr := format('TLS Version = %s, must be %0.1f or greater.'+#13#10+
                             'GitHub requires at least version 1.2'+#13#10+
-                            'Please follow the link to Microsoft for instructions on updating Windows.',[fTLSVersion,cDesiredVersion]);
+                            'Please click the blinking link for instructions from Microsoft on updating TLS.',[fTLSVersion,cDesiredVersion]);
   end
   else
   begin
     fMessageStr := format('Err: REST Status Code %d', [fStatusCode]);
     fTLSOk := false;
   end;
+  {$else}
+  fMessageStr := format('TLS Version = %s, must be %0.1f or greater.'+#13#10+
+                        'GitHub requires at least version 1.2'+#13#10+
+                        'Please click the blinking link for instructions from Microsoft on updating TLS',['1.0',cDesiredVersion]);
+  {$endif}
 end;
 
 function TCheckTLS.GetMessageStr: string;

--- a/Delphi/Project/Source/uInstallLocationFrm.pas
+++ b/Delphi/Project/Source/uInstallLocationFrm.pas
@@ -61,12 +61,14 @@ type
     lblUpdateTLS: TOvcURL;
     tmrCheckTLS: TTimer;
     imgV2Logo: TImage;
+    tmrToggler: TTimer;
     procedure btnCancelClick(Sender: TObject);
     procedure btnNextClick(Sender: TObject);
     procedure btnBrowseClick(Sender: TObject);
     procedure FormCreate(Sender: TObject);
     procedure FormActivate(Sender: TObject);
     procedure tmrCheckTLSTimer(Sender: TObject);
+    procedure tmrTogglerTimer(Sender: TObject);
   private
     { Private declarations }
   public
@@ -172,9 +174,15 @@ begin
   btnNext.Enabled := CheckTLS.TLSok;
   if not btnNext.Enabled then
   begin
+    tmrToggler.Enabled := true;
     lblUpdateTLS.Visible := true;
     MessageDlg(CheckTLS.ErrMessage,mtError,[mbok],0);
   end;
+end;
+
+procedure TfrmInstallLocation.tmrTogglerTimer(Sender: TObject);
+begin
+  lblUpdateTLS.Transparent := not lblUpdateTLS.Transparent;
 end;
 
 { TCheckTLS }


### PR DESCRIPTION
fixes #46
The failure message should now be more pronounced and more explicit to the user, indicating to them what the need to do in order to see the instructions provided my Microsoft for updating TLS on their computer.