### PR TITLE
Force TLS 1.2

### DIFF
--- a/Delphi/Project/ExercismCLIInstaller.dproj
+++ b/Delphi/Project/ExercismCLIInstaller.dproj
@@ -100,10 +100,13 @@
         <AppEnableHighDPI>true</AppEnableHighDPI>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
         <DCC_ExeOutput>Win32\Release</DCC_ExeOutput>
-        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.5.2.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=$(MSBuildProjectName);ProductVersion=1.5.2.0;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName)</VerInfo_Keys>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.5.3.2;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=$(MSBuildProjectName);ProductVersion=1.5;Comments=;ProgramID=com.embarcadero.$(MSBuildProjectName)</VerInfo_Keys>
         <DCC_DcuOutput>Win32\Release</DCC_DcuOutput>
         <VerInfo_MinorVer>5</VerInfo_MinorVer>
-        <VerInfo_Release>2</VerInfo_Release>
+        <VerInfo_Release>3</VerInfo_Release>
+        <VerInfo_Build>2</VerInfo_Build>
+        <VerInfo_PreRelease>true</VerInfo_PreRelease>
+        <VerInfo_AutoIncVersion>true</VerInfo_AutoIncVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2)'!=''">
         <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>

--- a/Delphi/Project/Source/uInstallLocationFrm.dfm
+++ b/Delphi/Project/Source/uInstallLocationFrm.dfm
@@ -1,6 +1,7 @@
 object frmInstallLocation: TfrmInstallLocation
   Left = 0
   Top = 0
+  ActiveControl = btnBrowse
   BorderIcons = []
   BorderStyle = bsDialog
   Caption = 'Exercism CLI Install'
@@ -14,7 +15,6 @@ object frmInstallLocation: TfrmInstallLocation
   Font.Style = []
   OldCreateOrder = False
   Position = poScreenCenter
-  OnActivate = FormActivate
   OnCreate = FormCreate
   PixelsPerInch = 96
   TextHeight = 13
@@ -69,31 +69,6 @@ object frmInstallLocation: TfrmInstallLocation
     ParentShowHint = False
     ShowHint = True
     Transparent = True
-  end
-  object lblUpdateTLS: TOvcURL
-    Left = 127
-    Top = 248
-    Width = 386
-    Height = 19
-    Hint = 
-      'https://support.microsoft.com/en-us/help/3140245/update-to-enabl' +
-      'e-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in'
-    Caption = 'Microsoft instructions for updating default TLS settings'
-    URL = 
-      'https://support.microsoft.com/en-us/help/3140245/update-to-enabl' +
-      'e-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in'
-    Color = clRed
-    Font.Charset = DEFAULT_CHARSET
-    Font.Color = clWindowText
-    Font.Height = -16
-    Font.Name = 'Tahoma'
-    Font.Style = [fsUnderline]
-    ParentColor = False
-    ParentFont = False
-    ParentShowHint = False
-    ShowHint = True
-    Transparent = True
-    Visible = False
   end
   object Panel1: TPanel
     Left = 0
@@ -6365,7 +6340,6 @@ object frmInstallLocation: TfrmInstallLocation
     Width = 75
     Height = 25
     Caption = '&Next >'
-    Enabled = False
     TabOrder = 2
     OnClick = btnNextClick
   end
@@ -6391,42 +6365,5 @@ object frmInstallLocation: TfrmInstallLocation
     Caption = '&Browse'
     TabOrder = 4
     OnClick = btnBrowseClick
-  end
-  object rcCheckTLSVersion: TRESTClient
-    Accept = 'application/json, text/plain; q=0.9, text/html;q=0.8,'
-    AcceptCharset = 'UTF-8, *;q=0.8'
-    BaseURL = 'https://www.howsmyssl.com/a/check'
-    Params = <>
-    HandleRedirects = True
-    RaiseExceptionOn500 = False
-    Left = 248
-    Top = 48
-  end
-  object rrCheckTLSVersion: TRESTRequest
-    Client = rcCheckTLSVersion
-    Params = <>
-    Response = rResponseCheckTLSVersion
-    SynchronizedEvents = False
-    Left = 328
-    Top = 52
-  end
-  object rResponseCheckTLSVersion: TRESTResponse
-    ContentType = 'application/json'
-    RootElement = 'tls_version'
-    Left = 416
-    Top = 48
-  end
-  object tmrCheckTLS: TTimer
-    Enabled = False
-    Interval = 200
-    OnTimer = tmrCheckTLSTimer
-    Left = 76
-    Top = 200
-  end
-  object tmrToggler: TTimer
-    Enabled = False
-    OnTimer = tmrTogglerTimer
-    Left = 508
-    Top = 192
   end
 end


### PR DESCRIPTION
fixes #48

Instead of relying on Windows having necessary TLS version setup properly.  Force correct version at run-time.

bump version 1.5.3


force btnBrowse to be active control

Without defining active control btnCancel was being selected at run-time.  Pressing enter would cause installer to exit.
replace literals with enumerated values

Remove Check TLS Version code
add exception handler

if RESTRequest1 should raise an exception lets capture it and allow the installer to exit gracefully instead of appearing to be hung.