### PR TITLE
fix: Append installation path to the environment variables

### DIFF
--- a/CSharp/clientDownload.cs
+++ b/CSharp/clientDownload.cs
@@ -108,8 +108,9 @@ namespace ExercismWinSetup
                     }
                 }
 
-                string pathContent = Environment.GetEnvironmentVariable("PATH") + ";" +_installationPath;
-                Environment.SetEnvironmentVariable("PATH", pathContent, EnvironmentVariableTarget.User);
+                AddToPathVariable(_installationPath);
+                // string pathContent = Environment.GetEnvironmentVariable("PATH") + ";" +_installationPath;
+                // Environment.SetEnvironmentVariable("PATH", pathContent, EnvironmentVariableTarget.User);
 
                 File.Delete(Path.GetTempPath() + @"\exercism.zip");
                 return true;
@@ -120,6 +121,20 @@ namespace ExercismWinSetup
             }
         }
 
+        private void AddToPathVariable(string pathToAdd)
+        {
+            const string name = "PATH";
+            var target = EnvironmentVariableTarget.User;            
+            var pathvar = System.Environment.GetEnvironmentVariable(name, target);
+            var isInPath = pathvar.Contains(pathToAdd);
+
+            if (!isInPath)
+            {                                
+                var value = pathvar + ";" + pathToAdd;
+                System.Environment.SetEnvironmentVariable(name, value, target);
+                Debug.Print(pathToAdd + " added to current user %PATH% environment variable");
+            }
+        }
         private bool queryGithub()
         {
             try


### PR DESCRIPTION
By not appending the path, all other user-defined path is removed.

closes #50

I apologize in advance here, because I'm totally unable to test the code before submitting it.
But do hope you can use it to fix this issue...

best regard
Hans-Petter Eitvet